### PR TITLE
Memory coherence mitigation

### DIFF
--- a/x9.c
+++ b/x9.c
@@ -58,9 +58,14 @@ typedef struct {
   char const    pad[5];
 } x9_msg_header;
 
+/* CPU cache line size */
+#define X9_CL_SIZE 64
+#define __x9_cl_aligned() __attribute__((__aligned__(X9_CL_SIZE)))
+
 typedef struct x9_inbox_internal {
-  _Atomic(uint64_t) read_idx;
-  _Atomic(uint64_t) write_idx;
+  _Atomic(uint64_t) read_idx __x9_cl_aligned();
+  _Atomic(uint64_t) write_idx __x9_cl_aligned();
+  uint64_t          __pad[7];
   uint64_t          sz;
   uint64_t          msg_sz;
   uint64_t          constant;
@@ -106,8 +111,9 @@ x9_inbox* x9_create_inbox(uint64_t const sz,
                           uint64_t const msg_sz) {
   if (!((sz > 0) && !(sz % 2))) { goto inbox_incorrect_size; }
 
-  x9_inbox* inbox = calloc(1, sizeof(x9_inbox));
+  x9_inbox* inbox = aligned_alloc(X9_CL_SIZE, sizeof(x9_inbox));
   if (NULL == inbox) { goto inbox_allocation_failed; }
+  memset(inbox, 0, sizeof(x9_inbox));
 
   uint64_t const name_len = strlen(name);
   char*          ibx_name = calloc(name_len + 1, sizeof(char));


### PR DESCRIPTION
Improve CPU cache miss ratio by aligning x9_inbox atomics to cache line.